### PR TITLE
Rectangle Perimeter Shape trait added

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod tests;
 pub trait Shape {
     fn area(&self) -> f64;
     fn circumference(&self) -> f64;
+    fn perimeter(&self) -> f64;
 }
 // ------------------------------------------------------------------------------------------------
 // Structs
@@ -138,16 +139,21 @@ impl Shape for Rectangle {
     fn area(&self) -> f64 {
         self.a * self.b
     }
-    /// Computes Circumference of given Rectangle
+
+    /// Skip implementation of circumference for Rectangle
     fn circumference(&self) -> f64 {
-        // TODO Calculate the circumference of the rectangle.
+        unimplemented!()
+    }
+
+    /// Computes Perimeter of given Rectangle
+    fn perimeter(&self) -> f64 {
+        // TODO Calculate the perimeter of the rectangle.
         todo!()
     }
 }
 
 // TODO Implement the Shape trait and its methods for the Circle struct
 // Hint: you can use std::f64::consts::PI
-
 // ------------------------------------------------------------------------------------------------
 // Examples
 //
@@ -263,11 +269,11 @@ impl fmt::Display for Rectangle {
             "-----------------------------------------------------------------\n".to_string();
         out.push_str("Printing Rectangle\n");
         out.push_str(&format!(
-            "a:{}, b:{}, area:{}, circumference:{}\n",
+            "a:{}, b:{}, area:{}, perimeter:{}\n",
             self.get_a(),
             self.get_b(),
             self.area(),
-            self.circumference(),
+            self.perimeter(),
         ));
         out.push_str("-----------------------------------------------------------------\n");
         write!(f, "{}", out)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -212,54 +212,54 @@ mod test {
         assert_eq!(computed_area, reference_area);
     }
     #[test]
-    fn rectangle_circumference() {
+    fn rectangle_perimeter() {
         let a_in: f64 = 15.0;
         let b_in: f64 = 7.0;
         let rectangle = Rectangle::try_new(&a_in, &b_in).unwrap();
 
-        assert_eq!(rectangle.circumference(), circumference!(a_in, b_in));
+        assert_eq!(rectangle.perimeter(), perimeter!(a_in, b_in));
 
-        let circumference = rectangle.circumference();
+        let perimeter = rectangle.perimeter();
 
-        let reference_circ = format!("{:.5}", circumference!(a_in, b_in));
-        let computed_circ = format!("{:.5}", circumference);
+        let reference_peri = format!("{:.5}", perimeter!(a_in, b_in));
+        let computed_peri = format!("{:.5}", perimeter);
 
-        assert_eq!(computed_circ, reference_circ);
+        assert_eq!(computed_peri, reference_peri);
     }
     #[test]
-    fn rectangle_circumference_with_set() {
+    fn rectangle_perimeter_with_set() {
         let a_in: f64 = 584.0;
         let b_in: f64 = 1287.0;
         let mut rectangle = Rectangle::try_new(&a_in, &b_in).unwrap();
 
-        let circumference = rectangle.circumference();
+        let perimeter = rectangle.perimeter();
 
-        let reference_circ = format!("{:.5}", circumference!(a_in, b_in));
-        let computed_circ = format!("{:.5}", circumference);
+        let reference_peri = format!("{:.5}", perimeter!(a_in, b_in));
+        let computed_peri = format!("{:.5}", perimeter);
 
-        assert_eq!(computed_circ, reference_circ);
+        assert_eq!(computed_peri, reference_peri);
 
         let new_a_in: f64 = 8.0;
         let res = rectangle.set_a(&new_a_in);
         assert!(res.is_ok());
 
-        let circumference = rectangle.circumference();
+        let perimeter = rectangle.perimeter();
 
-        let reference_circ = format!("{:.5}", circumference!(new_a_in, b_in));
-        let computed_circ = format!("{:.5}", circumference);
+        let reference_peri = format!("{:.5}", perimeter!(new_a_in, b_in));
+        let computed_peri = format!("{:.5}", perimeter);
 
-        assert_eq!(computed_circ, reference_circ);
+        assert_eq!(computed_peri, reference_peri);
 
         let new_b_in: f64 = 8.0;
         let res = rectangle.set_b(&new_b_in);
         assert!(res.is_ok());
 
-        let circumference = rectangle.circumference();
+        let perimeter = rectangle.perimeter();
 
-        let reference_circ = format!("{:.5}", circumference!(new_a_in, new_b_in));
-        let computed_circ = format!("{:.5}", circumference);
+        let reference_peri = format!("{:.5}", perimeter!(new_a_in, new_b_in));
+        let computed_peri = format!("{:.5}", perimeter);
 
-        assert_eq!(computed_circ, reference_circ);
+        assert_eq!(computed_peri, reference_peri);
     }
     #[test]
     fn circle_circumference() {
@@ -351,16 +351,16 @@ mod test {
                 assert!(rectangle.is_err());
             } else {
                 let rectangle = rectangle.unwrap();
-                let circumference = rectangle.circumference();
+                let perimeter = rectangle.perimeter();
                 let area = rectangle.area();
 
-                let reference_circ = format!("{:.5}", circumference!(a_in, b_in));
+                let reference_peri = format!("{:.5}", perimeter!(a_in, b_in));
                 let reference_area = format!("{:.5}", area!(a_in, b_in));
 
-                let computed_circ = format!("{:.5}", circumference);
+                let computed_peri = format!("{:.5}", perimeter);
                 let computed_area = format!("{:.5}", area);
 
-                assert_eq!(computed_circ, reference_circ);
+                assert_eq!(computed_peri, reference_peri);
                 assert_eq!(computed_area, reference_area);
             }
         }
@@ -368,6 +368,7 @@ mod test {
     use crate::area;
     use crate::circumference;
     use crate::op;
+    use crate::perimeter;
     use crate::Calculator;
     use crate::Circle;
     use crate::Rectangle;
@@ -383,10 +384,15 @@ mod my_macros {
         ($radius:ident) => {
             2.0 * $radius * std::f64::consts::PI
         };
-        ($a:ident,$b:ident) => {
+    }
+
+    #[macro_export]
+    macro_rules! perimeter {
+        ($a:ident, $b:ident) => {
             2.0 * $a + 2.0 * $b
         };
     }
+
     #[macro_export]
     macro_rules! area {
         ($radius:ident) => {


### PR DESCRIPTION
Instead of confining the Rectangle "perimeter" logic and computation into the shape trait "circumference", just add a perimeter trait in the shape. It makes it so that you can separate implementing perimeter and circumference logic on their own.